### PR TITLE
Add to Machine Learning Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Feel free to submit your own links and categories via [Pull Requests](https://gi
 
 ## Machine Learning
 [TensorFlow](https://www.tensorflow.org) an open-source software library for machine intelligence  
-[Theano](http://www.deeplearning.net/software/theano/) efficiently evaluate mathematical expressions involving multi-dimensional arrays  
+[Theano](http://www.deeplearning.net/software/theano/) efficiently evaluate mathematical expressions involving multi-dimensional arrays [Microsoft Cognitive Toolkit](https://github.com/Microsoft/CNTK) a unified deep-learning toolkit that describes neural networks as a series of computational steps via a directed graph
 [PyTorch](http://pytorch.org) is a deep learning framework that puts Python first  
 
 ## Podcasts


### PR DESCRIPTION
Adding Microsoft Cognitive Toolkit (available via Anaconda) to libraries available for ML in python.